### PR TITLE
Add FastAPI server and React Flow frontend

### DIFF
--- a/manimator-main/.gitignore
+++ b/manimator-main/.gitignore
@@ -1,4 +1,5 @@
 media/
+out/
 **/.gradio/
 manimator/.gradio/
 

--- a/manimator-main/main.py
+++ b/manimator-main/main.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://127.0.0.1:8000"],
+    allow_methods=["GET", "POST"],
+    allow_headers=["*"],
+)
+
+static_dir = Path(__file__).parent / "static"
+app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")
+
+out_dir = Path(__file__).parent / "out"
+out_dir.mkdir(exist_ok=True)
+app.mount("/out", StaticFiles(directory=out_dir), name="out")
+
+
+@app.post("/api/generate-animation")
+async def generate_animation(payload: dict):
+    """Generate a Manim animation from a text prompt.
+
+    This placeholder endpoint returns the path to a pre-rendered video.
+    """
+    prompt = payload.get("prompt", "")
+    video_path = out_dir / "result.mp4"
+    return JSONResponse({"video_url": f"/out/{video_path.name}"})

--- a/manimator-main/static/index.html
+++ b/manimator-main/static/index.html
@@ -26,24 +26,72 @@
       useEdgesState
     } = window.ReactFlow;
 
+    // 커스텀 비디오 노드: 렌더된 영상이 있으면 노드 안에서 재생
+    const VideoNode = ({ data }) => (
+      <div className="bg-white border rounded p-2 w-80">
+        {data.videoUrl ? (
+          <video controls className="w-full">
+            <source src={data.videoUrl} type="video/mp4" />
+          </video>
+        ) : (
+          <div className="text-center">Video Output</div>
+        )}
+      </div>
+    );
+
+    function NodeEditor({ selectedNode, onChange, renderManim, loading }) {
+      if (!selectedNode) return null;
+      return (
+        <aside className="absolute top-0 right-0 w-64 h-full bg-white border-l p-4 overflow-auto">
+          <h2 className="font-bold mb-2">{selectedNode.data.label}</h2>
+          {selectedNode.id !== 'output' ? (
+            <>
+              <textarea
+                className="w-full h-48 border p-2"
+                value={selectedNode.data.text || ''}
+                onChange={(e) => onChange(selectedNode.id, e.target.value)}
+              />
+              {selectedNode.id === '3' && (
+                <button
+                  className="mt-2 w-full bg-indigo-600 text-white py-1 rounded"
+                  onClick={() => renderManim(selectedNode.data.text)}
+                  disabled={loading}
+                >
+                  {loading ? '렌더링...' : '렌더링'}
+                </button>
+              )}
+            </>
+          ) : (
+            selectedNode.data.videoUrl ? (
+              <video controls className="w-full">
+                <source src={selectedNode.data.videoUrl} type="video/mp4" />
+              </video>
+            ) : (
+              <p>렌더된 영상이 없습니다.</p>
+            )
+          )}
+        </aside>
+      );
+    }
+
     function App() {
       const initialNodes = [
         { id: '1', position: { x: 0, y: 0 }, data: { label: 'OCR', text: '' } },
-        { id: '2', position: { x: 200, y: 0 }, data: { label: 'Storyboard', text: '' } },
-        { id: '3', position: { x: 400, y: 0 }, data: { label: 'Manim Code', text: '' } },
-        { id: 'output', position: { x: 200, y: 200 }, data: { label: 'Video Output' } }
+        { id: '2', position: { x: 250, y: 0 }, data: { label: 'Storyboard', text: '' } },
+        { id: '3', position: { x: 500, y: 0 }, data: { label: 'Manim Code', text: '' } },
+        { id: 'output', position: { x: 250, y: 200 }, data: { label: 'Video Output', videoUrl: null }, type: 'video' }
       ];
 
       const initialEdges = [
-        { id: 'e1', source: '1', target: 'output' },
-        { id: 'e2', source: '2', target: 'output' },
-        { id: 'e3', source: '3', target: 'output' }
+        { id: 'e1-2', source: '1', target: 'output' },
+        { id: 'e2-2', source: '2', target: 'output' },
+        { id: 'e3-2', source: '3', target: 'output' }
       ];
 
+      const nodeTypes = { video: VideoNode };
       const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
       const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
       const [selected, setSelected] = useState(null);
-      const [videoUrl, setVideoUrl] = useState(null);
       const [loading, setLoading] = useState(false);
 
       const onConnect = (params) => setEdges((eds) => addEdge(params, eds));
@@ -53,18 +101,17 @@
         setNodes((ns) => ns.map((n) => n.id === id ? { ...n, data: { ...n.data, text } } : n));
       };
 
-      const renderManim = async () => {
-        if (!selected) return;
+      const renderManim = async (code) => {
         setLoading(true);
         try {
           const res = await fetch('/api/generate-animation', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ prompt: selected.data.text || '' })
+            body: JSON.stringify({ prompt: code || '' })
           });
           if (!res.ok) throw new Error('HTTP ' + res.status);
           const data = await res.json();
-          setVideoUrl(data.video_url);
+          setNodes((ns) => ns.map((n) => n.id === 'output' ? { ...n, data: { ...n.data, videoUrl: data.video_url } } : n));
         } catch (e) {
           alert(e);
         } finally {
@@ -81,6 +128,7 @@
             onEdgesChange={onEdgesChange}
             onConnect={onConnect}
             onNodeClick={onNodeClick}
+            nodeTypes={nodeTypes}
             fitView
             className="h-full"
           >
@@ -89,45 +137,12 @@
             <MiniMap />
           </Flow>
 
-          {videoUrl && (
-            <div className="absolute bottom-4 left-4 right-4 bg-white p-2 shadow rounded">
-              <video controls className="w-full">
-                <source src={videoUrl} type="video/mp4" />
-              </video>
-            </div>
-          )}
-
-          {selected && (
-            <div className="absolute top-0 right-0 w-64 h-full bg-white border-l p-4 overflow-auto">
-              <h2 className="font-bold mb-2">{selected.data.label}</h2>
-              {selected.id !== 'output' ? (
-                <>
-                  <textarea
-                    className="w-full h-48 border p-2"
-                    value={selected.data.text || ''}
-                    onChange={(e) => updateNodeText(selected.id, e.target.value)}
-                  />
-                  {selected.id === '3' && (
-                    <button
-                      onClick={renderManim}
-                      disabled={loading}
-                      className="mt-2 w-full bg-indigo-600 text-white py-1 rounded"
-                    >
-                      {loading ? '렌더링...' : '렌더링'}
-                    </button>
-                  )}
-                </>
-              ) : (
-                videoUrl ? (
-                  <video controls className="w-full">
-                    <source src={videoUrl} type="video/mp4" />
-                  </video>
-                ) : (
-                  <p>렌더된 영상이 없습니다.</p>
-                )
-              )}
-            </div>
-          )}
+          <NodeEditor
+            selectedNode={selected}
+            onChange={updateNodeText}
+            renderManim={renderManim}
+            loading={loading}
+          />
         </div>
       );
     }

--- a/manimator-main/static/index.html
+++ b/manimator-main/static/index.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Manimator Web</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/reactflow@11/dist/style.css" />
+  <script src="https://unpkg.com/reactflow@11/dist/reactflow.production.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="h-screen">
+  <div id="root" class="h-full"></div>
+
+  <script type="text/babel">
+    const { useState } = React;
+    const {
+      ReactFlow: Flow,
+      MiniMap,
+      Controls,
+      Background,
+      addEdge,
+      useNodesState,
+      useEdgesState
+    } = window.ReactFlow;
+
+    function App() {
+      const initialNodes = [
+        { id: '1', position: { x: 0, y: 0 }, data: { label: 'OCR', text: '' } },
+        { id: '2', position: { x: 200, y: 0 }, data: { label: 'Storyboard', text: '' } },
+        { id: '3', position: { x: 400, y: 0 }, data: { label: 'Manim Code', text: '' } },
+        { id: 'output', position: { x: 200, y: 200 }, data: { label: 'Video Output' } }
+      ];
+
+      const initialEdges = [
+        { id: 'e1', source: '1', target: 'output' },
+        { id: 'e2', source: '2', target: 'output' },
+        { id: 'e3', source: '3', target: 'output' }
+      ];
+
+      const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+      const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+      const [selected, setSelected] = useState(null);
+      const [videoUrl, setVideoUrl] = useState(null);
+      const [loading, setLoading] = useState(false);
+
+      const onConnect = (params) => setEdges((eds) => addEdge(params, eds));
+      const onNodeClick = (evt, node) => setSelected(node);
+
+      const updateNodeText = (id, text) => {
+        setNodes((ns) => ns.map((n) => n.id === id ? { ...n, data: { ...n.data, text } } : n));
+      };
+
+      const renderManim = async () => {
+        if (!selected) return;
+        setLoading(true);
+        try {
+          const res = await fetch('/api/generate-animation', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ prompt: selected.data.text || '' })
+          });
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          const data = await res.json();
+          setVideoUrl(data.video_url);
+        } catch (e) {
+          alert(e);
+        } finally {
+          setLoading(false);
+        }
+      };
+
+      return (
+        <div className="h-full relative">
+          <Flow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={onConnect}
+            onNodeClick={onNodeClick}
+            fitView
+            className="h-full"
+          >
+            <Background />
+            <Controls />
+            <MiniMap />
+          </Flow>
+
+          {videoUrl && (
+            <div className="absolute bottom-4 left-4 right-4 bg-white p-2 shadow rounded">
+              <video controls className="w-full">
+                <source src={videoUrl} type="video/mp4" />
+              </video>
+            </div>
+          )}
+
+          {selected && (
+            <div className="absolute top-0 right-0 w-64 h-full bg-white border-l p-4 overflow-auto">
+              <h2 className="font-bold mb-2">{selected.data.label}</h2>
+              {selected.id !== 'output' ? (
+                <>
+                  <textarea
+                    className="w-full h-48 border p-2"
+                    value={selected.data.text || ''}
+                    onChange={(e) => updateNodeText(selected.id, e.target.value)}
+                  />
+                  {selected.id === '3' && (
+                    <button
+                      onClick={renderManim}
+                      disabled={loading}
+                      className="mt-2 w-full bg-indigo-600 text-white py-1 rounded"
+                    >
+                      {loading ? '렌더링...' : '렌더링'}
+                    </button>
+                  )}
+                </>
+              ) : (
+                videoUrl ? (
+                  <video controls className="w-full">
+                    <source src={videoUrl} type="video/mp4" />
+                  </video>
+                ) : (
+                  <p>렌더된 영상이 없습니다.</p>
+                )
+              )}
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve static frontend and placeholder API via FastAPI
- add React Flow-based editor for OCR/Storyboard/Manim nodes
- ignore generated video output directory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a59f5ee260832291a2959c951a277a